### PR TITLE
[3주차-과제1] 'To-do 테스트 작성하기' 코드 리뷰

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "coverage": "npm run test:unit -- --coverage",
     "test:e2e": "codeceptjs run --steps",
     "test": "npm run coverage && start-server-and-test start http://localhost:8080 test:e2e",
-    "lint": "eslint --ext js,jsx ."
+    "lint": "eslint --ext js,jsx .",
+    "test:watch": "npx jest --watchAll --coverage --verbose"
   },
   "keywords": [],
   "author": "",

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+import { render, fireEvent, screen } from '@testing-library/react';
+
+import App from './App';
+
+function setup() {
+  render(<App />);
+  const changeInput = (text) => fireEvent.change(screen.getByLabelText(/할 일/i, { selector: 'input' }),
+    { target: { value: text } });
+  const clickAddButton = () => fireEvent.click(screen.getByRole('button', { name: /추가/i }));
+  const clickDoneButton = () => fireEvent.click(screen.getAllByRole('button', { name: /완료/i })[0]);
+  return { changeInput, clickAddButton, clickDoneButton };
+}
+
+test('아무런 To-do가 등록되어 있지 않으면 "할 일이 없어요!"라는 메시지가 보인다', () => {
+  setup();
+  expect(screen.getByText('할 일이 없어요!')).toBeInTheDocument();
+});
+
+test('할 일을 입력하고 추가를 누르면 할 일 목록에 추가한 목록이 보인다', () => {
+  const { changeInput, clickAddButton } = setup();
+  changeInput('아무것도 하지 않기');
+  clickAddButton();
+  expect(screen.getByText('아무것도 하지 않기')).toBeInTheDocument();
+});
+
+test('할 일을 입력하고 추가를 누르면 input의 텍스트가 지워진다', () => {
+  const { changeInput, clickAddButton } = setup();
+  changeInput('아무것도 하지 않기');
+  clickAddButton();
+  const inputElement = screen.getByLabelText(/할 일/i, { selector: 'input' });
+  expect(inputElement.value).toBe('');
+});
+
+test('할 일을 완료하면 할 일이 목록에서 보이지 않는다', () => {
+  const tasks = ['코드숨 과제하기', '아무것도 하지 않기'];
+  const { changeInput, clickAddButton, clickDoneButton } = setup();
+
+  tasks.forEach((task) => {
+    changeInput(task);
+    clickAddButton();
+  });
+
+  tasks.forEach(() => clickDoneButton());
+  tasks.forEach((task) => expect(screen.queryByText(task)).not.toBeInTheDocument());
+});

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -4,44 +4,50 @@ import { render, fireEvent, screen } from '@testing-library/react';
 
 import App from './App';
 
-function setup() {
+function renderApp() {
   render(<App />);
-  const changeInput = (text) => fireEvent.change(screen.getByLabelText(/할 일/i, { selector: 'input' }),
-    { target: { value: text } });
-  const clickAddButton = () => fireEvent.click(screen.getByRole('button', { name: /추가/i }));
-  const clickDoneButton = () => fireEvent.click(screen.getAllByRole('button', { name: /완료/i })[0]);
-  return { changeInput, clickAddButton, clickDoneButton };
+  return {
+    taskInput: screen.getByLabelText(/할 일/i, { selector: 'input' }),
+    taskAddButton: screen.getByRole('button', { name: /추가/i }),
+    getTaskDoneButtons: () => screen.queryAllByRole('button', { name: /완료/i }),
+  };
 }
 
 test('아무런 To-do가 등록되어 있지 않으면 "할 일이 없어요!"라는 메시지가 보인다', () => {
-  setup();
-  expect(screen.getByText('할 일이 없어요!')).toBeInTheDocument();
+  // when
+  renderApp();
+  // then
+  expect(screen.getByText(/할 일이 없어요!/i)).toBeInTheDocument();
 });
 
 test('할 일을 입력하고 추가를 누르면 할 일 목록에 추가한 목록이 보인다', () => {
-  const { changeInput, clickAddButton } = setup();
-  changeInput('아무것도 하지 않기');
-  clickAddButton();
+  // when
+  const { taskInput, taskAddButton } = renderApp();
+  fireEvent.change(taskInput, { target: { value: '아무것도 하지 않기' } });
+  fireEvent.click(taskAddButton);
+  // then
   expect(screen.getByText('아무것도 하지 않기')).toBeInTheDocument();
 });
 
 test('할 일을 입력하고 추가를 누르면 input의 텍스트가 지워진다', () => {
-  const { changeInput, clickAddButton } = setup();
-  changeInput('아무것도 하지 않기');
-  clickAddButton();
-  const inputElement = screen.getByLabelText(/할 일/i, { selector: 'input' });
-  expect(inputElement.value).toBe('');
+  // when
+  const { taskInput, taskAddButton } = renderApp();
+  fireEvent.change(taskInput, { target: { value: '아무것도 하지 않기' } });
+  fireEvent.click(taskAddButton);
+  // then
+  expect(taskInput.value).toBe('');
 });
 
 test('할 일을 완료하면 할 일이 목록에서 보이지 않는다', () => {
+  // given
   const tasks = ['코드숨 과제하기', '아무것도 하지 않기'];
-  const { changeInput, clickAddButton, clickDoneButton } = setup();
-
+  // when
+  const { taskInput, taskAddButton, getTaskDoneButtons } = renderApp();
   tasks.forEach((task) => {
-    changeInput(task);
-    clickAddButton();
+    fireEvent.change(taskInput, { target: { value: task } });
+    fireEvent.click(taskAddButton);
   });
-
-  tasks.forEach(() => clickDoneButton());
+  // then
+  tasks.forEach(() => fireEvent.click(getTaskDoneButtons()[0]));
   tasks.forEach((task) => expect(screen.queryByText(task)).not.toBeInTheDocument());
 });

--- a/src/Input.test.jsx
+++ b/src/Input.test.jsx
@@ -13,10 +13,7 @@ function setup(value, handleChange, handleClick) {
   const changeTaskInput = (text) => fireEvent.change(screen.getByLabelText(/할 일/i, { selector: 'input' }),
     { target: { value: text } });
   const clickAddButton = () => fireEvent.click(screen.getByRole('button', { name: /추가/i }));
-  return {
-    changeTaskInput,
-    clickAddButton,
-  };
+  return { changeTaskInput, clickAddButton };
 }
 
 describe('Input Component는', () => {

--- a/src/Input.test.jsx
+++ b/src/Input.test.jsx
@@ -36,6 +36,7 @@ describe('Input Component는', () => {
         expect(screen.getByPlaceholderText(placeholderText)).toBeInTheDocument();
       });
     });
+
     describe('비어 있지 않다면', () => {
       test('value 값을 출력한다.', () => {
         const value = '어제보다 열심히 하기';

--- a/src/Input.test.jsx
+++ b/src/Input.test.jsx
@@ -4,58 +4,75 @@ import { render, fireEvent, screen } from '@testing-library/react';
 
 import Input from './Input';
 
-function setup(value, handleChange, handleClick) {
+function renderInput({ value, onChange, onClick }) {
   render(<Input
     value={value}
-    onChange={handleChange}
-    onClick={handleClick}
+    onChange={onChange}
+    onClick={onClick}
   />);
-  const changeTaskInput = (text) => fireEvent.change(screen.getByLabelText(/할 일/i, { selector: 'input' }),
-    { target: { value: text } });
-  const clickAddButton = () => fireEvent.click(screen.getByRole('button', { name: /추가/i }));
-  return { changeTaskInput, clickAddButton };
+
+  const taskTitleInput = screen.getByLabelText(/할 일/i, { selector: 'input' });
+  const addButton = screen.getByRole('button', { name: /추가/i });
+
+  return {
+    taskTitleInput,
+    changeTaskInput: (text) => fireEvent.change(taskTitleInput, { target: { value: text } }),
+    clickAddButton: () => fireEvent.click(addButton),
+  };
 }
 
-describe('Input Component는', () => {
-  const mockHandleChange = jest.fn();
-  const mockHandleClick = jest.fn();
-
-  beforeEach(() => {
-    mockHandleChange.mockClear();
-    mockHandleClick.mockClear();
+describe('<Input />', () => {
+  context('without input value', () => {
+    it('print guide message', () => {
+      // given
+      const value = '';
+      // when
+      const { taskTitleInput } = renderInput({ value, onChange: jest.fn(), onClick: jest.fn() });
+      // then
+      expect(taskTitleInput.placeholder).toBe('할 일을 입력해 주세요');
+    });
   });
 
-  describe('value 값이', () => {
-    describe('비어 있다면', () => {
-      test('입력 안내 메시지를 출력한다', () => {
-        const placeholderText = '할 일을 입력해 주세요';
-        setup('', mockHandleChange, mockHandleClick);
-        expect(screen.getByPlaceholderText(placeholderText)).toBeInTheDocument();
+  context('with input value', () => {
+    it('print input value', () => {
+      // given
+      const value = '어제보다 열심히 하기';
+      // when
+      const { taskTitleInput } = renderInput({ value, onChange: jest.fn(), onClick: jest.fn() });
+      // then
+      expect(taskTitleInput.value).toBe(value);
+    });
+  });
+
+  context('when clicked button', () => {
+    it('notify that it has been clicked', () => {
+      // given
+      const handleClick = jest.fn();
+      // when
+      const { clickAddButton } = renderInput({
+        value: '오늘 할 일',
+        onChange: jest.fn(),
+        onClick: handleClick,
       });
-    });
-
-    describe('비어 있지 않다면', () => {
-      test('value 값을 출력한다.', () => {
-        const value = '어제보다 열심히 하기';
-        setup(value, mockHandleChange, mockHandleClick);
-        expect(screen.getByDisplayValue(value)).toBeInTheDocument();
-      });
-    });
-  });
-
-  describe('텍스트를 입력하면', () => {
-    test('onChange를 실행한다', () => {
-      const { changeTaskInput } = setup('어제보다 열심히 하기', mockHandleChange, mockHandleClick);
-      changeTaskInput('새롭게 해야할 일');
-      expect(mockHandleChange).toBeCalledTimes(1);
-    });
-  });
-
-  describe('추가 버튼을 누르면', () => {
-    test('onClick을 실행한다', () => {
-      const { clickAddButton } = setup('어제보다 열심히 하기', mockHandleChange, mockHandleClick);
       clickAddButton();
-      expect(mockHandleClick).toBeCalledTimes(1);
+      // then
+      expect(handleClick).toBeCalledTimes(1);
+    });
+  });
+
+  context('when an input field is entered', () => {
+    it('notify that it has been entered', () => {
+      // given
+      const handleChange = jest.fn();
+      // when
+      const { changeTaskInput } = renderInput({
+        value: '오늘 할 일',
+        onChange: handleChange,
+        onClick: jest.fn(),
+      });
+      changeTaskInput('내일 할 일');
+      // then
+      expect(handleChange).toBeCalledTimes(1);
     });
   });
 });

--- a/src/Input.test.jsx
+++ b/src/Input.test.jsx
@@ -4,40 +4,42 @@ import { render, fireEvent, screen } from '@testing-library/react';
 
 import Input from './Input';
 
+function setup(value, handleChange, handleClick) {
+  render(<Input
+    value={value}
+    onChange={handleChange}
+    onClick={handleClick}
+  />);
+  const changeTaskInput = (text) => fireEvent.change(screen.getByLabelText(/할 일/i, { selector: 'input' }),
+    { target: { value: text } });
+  const clickAddButton = () => fireEvent.click(screen.getByRole('button', { name: /추가/i }));
+  return {
+    changeTaskInput,
+    clickAddButton,
+  };
+}
+
 describe('Input Component는', () => {
-  const mockOnChange = jest.fn();
-  const mockOnClick = jest.fn();
+  const mockHandleChange = jest.fn();
+  const mockHandleClick = jest.fn();
 
   beforeEach(() => {
-    mockOnChange.mockClear();
-    mockOnClick.mockClear();
+    mockHandleChange.mockClear();
+    mockHandleClick.mockClear();
   });
 
   describe('value 값이', () => {
     describe('비어 있다면', () => {
       test('입력 안내 메시지를 출력한다', () => {
         const placeholderText = '할 일을 입력해 주세요';
-        const value = '';
-
-        render(<Input
-          value={value}
-          onChange={mockOnChange}
-          onClick={mockOnClick}
-        />);
-
+        setup('', mockHandleChange, mockHandleClick);
         expect(screen.getByPlaceholderText(placeholderText)).toBeInTheDocument();
       });
     });
     describe('비어 있지 않다면', () => {
       test('value 값을 출력한다.', () => {
         const value = '어제보다 열심히 하기';
-
-        render(<Input
-          value={value}
-          onChange={mockOnChange}
-          onClick={mockOnClick}
-        />);
-
+        setup(value, mockHandleChange, mockHandleClick);
         expect(screen.getByDisplayValue(value)).toBeInTheDocument();
       });
     });
@@ -45,30 +47,17 @@ describe('Input Component는', () => {
 
   describe('텍스트를 입력하면', () => {
     test('onChange를 실행한다', () => {
-      const inputValue = '오늘보다 열심히 하기';
-
-      render(<Input
-        value=""
-        onChange={mockOnChange}
-        onClick={mockOnClick}
-      />);
-      fireEvent.change(screen.getByLabelText(/할 일/i, { selector: 'input' }),
-        { target: { value: inputValue } });
-
-      expect(mockOnChange).toBeCalledTimes(1);
+      const { changeTaskInput } = setup('어제보다 열심히 하기', mockHandleChange, mockHandleClick);
+      changeTaskInput('새롭게 해야할 일');
+      expect(mockHandleChange).toBeCalledTimes(1);
     });
   });
 
   describe('추가 버튼을 누르면', () => {
     test('onClick을 실행한다', () => {
-      render(<Input
-        value="어제보다 열심히 하기"
-        onChange={mockOnChange}
-        onClick={mockOnClick}
-      />);
-      fireEvent.click(screen.getByRole('button', { name: /추가/i }));
-
-      expect(mockOnClick).toBeCalledTimes(1);
+      const { clickAddButton } = setup('어제보다 열심히 하기', mockHandleChange, mockHandleClick);
+      clickAddButton();
+      expect(mockHandleClick).toBeCalledTimes(1);
     });
   });
 });

--- a/src/Input.test.jsx
+++ b/src/Input.test.jsx
@@ -4,20 +4,19 @@ import { render, fireEvent, screen } from '@testing-library/react';
 
 import Input from './Input';
 
-function renderInput({ value, onChange, onClick }) {
+const handleClick = jest.fn();
+const handleChange = jest.fn();
+
+function renderInput(value) {
   render(<Input
     value={value}
-    onChange={onChange}
-    onClick={onClick}
+    onChange={handleChange}
+    onClick={handleClick}
   />);
 
-  const taskTitleInput = screen.getByLabelText(/할 일/i, { selector: 'input' });
-  const addButton = screen.getByRole('button', { name: /추가/i });
-
   return {
-    taskTitleInput,
-    changeTaskInput: (text) => fireEvent.change(taskTitleInput, { target: { value: text } }),
-    clickAddButton: () => fireEvent.click(addButton),
+    taskTitleInput: screen.getByLabelText(/할 일/i, { selector: 'input' }),
+    addButton: screen.getByRole('button', { name: /추가/i }),
   };
 }
 
@@ -27,7 +26,7 @@ describe('<Input />', () => {
       // given
       const value = '';
       // when
-      const { taskTitleInput } = renderInput({ value, onChange: jest.fn(), onClick: jest.fn() });
+      const { taskTitleInput } = renderInput(value);
       // then
       expect(taskTitleInput.placeholder).toBe('할 일을 입력해 주세요');
     });
@@ -38,7 +37,7 @@ describe('<Input />', () => {
       // given
       const value = '어제보다 열심히 하기';
       // when
-      const { taskTitleInput } = renderInput({ value, onChange: jest.fn(), onClick: jest.fn() });
+      const { taskTitleInput } = renderInput(value);
       // then
       expect(taskTitleInput.value).toBe(value);
     });
@@ -47,14 +46,10 @@ describe('<Input />', () => {
   context('when clicked button', () => {
     it('notify that it has been clicked', () => {
       // given
-      const handleClick = jest.fn();
+      handleClick.mockClear();
       // when
-      const { clickAddButton } = renderInput({
-        value: '오늘 할 일',
-        onChange: jest.fn(),
-        onClick: handleClick,
-      });
-      clickAddButton();
+      const { addButton } = renderInput('오늘 할 일');
+      fireEvent.click(addButton);
       // then
       expect(handleClick).toBeCalledTimes(1);
     });
@@ -63,14 +58,10 @@ describe('<Input />', () => {
   context('when an input field is entered', () => {
     it('notify that it has been entered', () => {
       // given
-      const handleChange = jest.fn();
+      handleChange.mockClear();
       // when
-      const { changeTaskInput } = renderInput({
-        value: '오늘 할 일',
-        onChange: handleChange,
-        onClick: jest.fn(),
-      });
-      changeTaskInput('내일 할 일');
+      const { taskTitleInput } = renderInput('오늘 할 일');
+      fireEvent.change(taskTitleInput, { target: { value: '내일 할 일' } });
       // then
       expect(handleChange).toBeCalledTimes(1);
     });

--- a/src/Input.test.jsx
+++ b/src/Input.test.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+
+import { render, fireEvent, screen } from '@testing-library/react';
+
+import Input from './Input';
+
+describe('Input Component는', () => {
+  const mockOnChange = jest.fn();
+  const mockOnClick = jest.fn();
+
+  beforeEach(() => {
+    mockOnChange.mockClear();
+    mockOnClick.mockClear();
+  });
+
+  describe('value 값이', () => {
+    describe('비어 있다면', () => {
+      test('입력 안내 메시지를 출력한다', () => {
+        const placeholderText = '할 일을 입력해 주세요';
+        const value = '';
+
+        render(<Input
+          value={value}
+          onChange={mockOnChange}
+          onClick={mockOnClick}
+        />);
+
+        expect(screen.getByPlaceholderText(placeholderText)).toBeInTheDocument();
+      });
+    });
+    describe('비어 있지 않다면', () => {
+      test('value 값을 출력한다.', () => {
+        const value = '어제보다 열심히 하기';
+
+        render(<Input
+          value={value}
+          onChange={mockOnChange}
+          onClick={mockOnClick}
+        />);
+
+        expect(screen.getByDisplayValue(value)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('텍스트를 입력하면', () => {
+    test('onChange를 실행한다', () => {
+      const inputValue = '오늘보다 열심히 하기';
+
+      render(<Input
+        value=""
+        onChange={mockOnChange}
+        onClick={mockOnClick}
+      />);
+      fireEvent.change(screen.getByLabelText(/할 일/i, { selector: 'input' }),
+        { target: { value: inputValue } });
+
+      expect(mockOnChange).toBeCalledTimes(1);
+    });
+  });
+
+  describe('추가 버튼을 누르면', () => {
+    test('onClick을 실행한다', () => {
+      render(<Input
+        value="어제보다 열심히 하기"
+        onChange={mockOnChange}
+        onClick={mockOnClick}
+      />);
+      fireEvent.click(screen.getByRole('button', { name: /추가/i }));
+
+      expect(mockOnClick).toBeCalledTimes(1);
+    });
+  });
+});

--- a/src/Item.test.jsx
+++ b/src/Item.test.jsx
@@ -1,30 +1,37 @@
 import React from 'react';
 
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 
 import Item from './Item';
 
-test('Item', () => {
-  const task = {
-    id: 1,
-    title: '뭐라도 하기',
-  };
+function setup(task, handleClickDelete) {
+  render(<Item
+    task={task}
+    onClickDelete={handleClickDelete}
+  />);
+  const clickDeleteButton = () => fireEvent.click(screen.getByRole('button', { name: /완료/i }));
+  return { clickDeleteButton };
+}
 
-  const handleClick = jest.fn();
+describe('Item Component는', () => {
+  const mockHandleClick = jest.fn();
+  const task = { id: 1, title: '뭐라도 하기' };
 
-  const { container, getByText } = render((
-    <Item
-      task={task}
-      onClickDelete={handleClick}
-    />
-  ));
+  beforeEach(() => {
+    mockHandleClick.mockClear();
+  });
 
-  expect(container).toHaveTextContent('뭐라도 하기');
-  expect(container).toHaveTextContent('완료');
+  test('task를 출력한다', () => {
+    setup(task, mockHandleClick);
+    expect(screen.getByText(task.title)).toBeInTheDocument();
+  });
 
-  expect(handleClick).not.toBeCalled();
-
-  fireEvent.click(getByText('완료'));
-
-  expect(handleClick).toBeCalledWith(1);
+  describe('완료 버튼을 누르면', () => {
+    test('onClickDelete를 실행한다', () => {
+      const { clickDeleteButton } = setup(task, mockHandleClick);
+      expect(mockHandleClick).not.toBeCalled();
+      clickDeleteButton();
+      expect(mockHandleClick).toBeCalledWith(1);
+    });
+  });
 });

--- a/src/Item.test.jsx
+++ b/src/Item.test.jsx
@@ -4,18 +4,17 @@ import { render, fireEvent, screen } from '@testing-library/react';
 
 import Item from './Item';
 
-function renderItem({ task, onClickDelete }) {
+const handleClickDelete = jest.fn();
+
+function renderItem(task) {
   render(<Item
     task={task}
-    onClickDelete={onClickDelete}
+    onClickDelete={handleClickDelete}
   />);
 
-  const titleElement = screen.getByText(task.title);
-  const deleteButton = screen.getByRole('button', { name: /완료/i });
-
   return {
-    titleElement,
-    clickDeleteButton: () => fireEvent.click(deleteButton),
+    titleElement: screen.getByText(task.title),
+    deleteButton: screen.getByRole('button', { name: /완료/i }),
   };
 }
 
@@ -25,7 +24,7 @@ describe('<Item />', () => {
       // given
       const task = { id: 1, title: '오늘 할 일' };
       // when
-      const { titleElement } = renderItem({ task, onClickDelete: jest.fn() });
+      const { titleElement } = renderItem(task);
       // then
       expect(titleElement).toBeInTheDocument();
     });
@@ -35,10 +34,10 @@ describe('<Item />', () => {
     it('notify which task has been clicked', () => {
       // given
       const task = { id: 1, title: '오늘 할 일' };
-      const handleClickDelete = jest.fn();
+      handleClickDelete.mockClear();
       // when
-      const { clickDeleteButton } = renderItem({ task, onClickDelete: handleClickDelete });
-      clickDeleteButton();
+      const { deleteButton } = renderItem(task);
+      fireEvent.click(deleteButton);
       // then
       expect(handleClickDelete).toBeCalledTimes(1);
       expect(handleClickDelete).toBeCalledWith(task.id);

--- a/src/Item.test.jsx
+++ b/src/Item.test.jsx
@@ -4,34 +4,44 @@ import { render, fireEvent, screen } from '@testing-library/react';
 
 import Item from './Item';
 
-function setup(task, handleClickDelete) {
+function renderItem({ task, onClickDelete }) {
   render(<Item
     task={task}
-    onClickDelete={handleClickDelete}
+    onClickDelete={onClickDelete}
   />);
-  const clickDeleteButton = () => fireEvent.click(screen.getByRole('button', { name: /완료/i }));
-  return { clickDeleteButton };
+
+  const titleElement = screen.getByText(task.title);
+  const deleteButton = screen.getByRole('button', { name: /완료/i });
+
+  return {
+    titleElement,
+    clickDeleteButton: () => fireEvent.click(deleteButton),
+  };
 }
 
-describe('Item Component는', () => {
-  const mockHandleClick = jest.fn();
-  const task = { id: 1, title: '뭐라도 하기' };
-
-  beforeEach(() => {
-    mockHandleClick.mockClear();
+describe('<Item />', () => {
+  context('with task', () => {
+    it('print title of task', () => {
+      // given
+      const task = { id: 1, title: '오늘 할 일' };
+      // when
+      const { titleElement } = renderItem({ task, onClickDelete: jest.fn() });
+      // then
+      expect(titleElement).toBeInTheDocument();
+    });
   });
 
-  test('task를 출력한다', () => {
-    setup(task, mockHandleClick);
-    expect(screen.getByText(task.title)).toBeInTheDocument();
-  });
-
-  describe('완료 버튼을 누르면', () => {
-    test('onClickDelete를 실행한다', () => {
-      const { clickDeleteButton } = setup(task, mockHandleClick);
-      expect(mockHandleClick).not.toBeCalled();
+  context('when clicked delete button', () => {
+    it('notify which task has been clicked', () => {
+      // given
+      const task = { id: 1, title: '오늘 할 일' };
+      const handleClickDelete = jest.fn();
+      // when
+      const { clickDeleteButton } = renderItem({ task, onClickDelete: handleClickDelete });
       clickDeleteButton();
-      expect(mockHandleClick).toBeCalledWith(1);
+      // then
+      expect(handleClickDelete).toBeCalledTimes(1);
+      expect(handleClickDelete).toBeCalledWith(task.id);
     });
   });
 });

--- a/src/List.test.jsx
+++ b/src/List.test.jsx
@@ -43,7 +43,7 @@ describe('List Component는', () => {
       expect(screen.getByRole('list', { name: '' }).children).toHaveLength(itemSize);
     });
 
-    describe('Item에서 완료 버튼을 클릭했을 때', () => {
+    describe('Item의 완료 버튼을 클릭했을 때', () => {
       test('onClickDelete를 실행한다', () => {
         const { clickDoneButton } = setup(tasks, mockHandleClickDelete);
         clickDoneButton();

--- a/src/List.test.jsx
+++ b/src/List.test.jsx
@@ -4,21 +4,18 @@ import { render, fireEvent, screen } from '@testing-library/react';
 
 import List from './List';
 
-function renderList({ tasks, onClickDelete }) {
+const handleClickDelete = jest.fn();
+
+function renderList(tasks) {
   render(<List
     tasks={tasks}
-    onClickDelete={onClickDelete}
+    onClickDelete={handleClickDelete}
   />);
 
-  const nothingTaskMessageElement = screen.queryByText(/할 일이 없어요!/i);
-  const taskListItems = screen.queryAllByRole('listitem', { name: '' });
-  const doneButtons = screen.queryAllByRole('button', { name: /완료/i });
-
   return {
-    nothingTaskMessageElement,
-    taskListItems,
-    doneButtons,
-    clickDoneButton: (index) => fireEvent.click(doneButtons[index]),
+    nothingTaskMessageElement: screen.queryByText(/할 일이 없어요!/i),
+    taskListItems: screen.queryAllByRole('listitem', { name: '' }),
+    doneButtons: screen.queryAllByRole('button', { name: /완료/i }),
   };
 }
 
@@ -28,7 +25,7 @@ describe('<List />', () => {
       // given
       const tasks = [];
       // when
-      const { nothingTaskMessageElement } = renderList({ tasks, onClickDelete: jest.fn() });
+      const { nothingTaskMessageElement } = renderList(tasks);
       // then
       expect(nothingTaskMessageElement).toBeInTheDocument();
     });
@@ -37,7 +34,7 @@ describe('<List />', () => {
       // given
       const tasks = [];
       // when
-      const { taskListItems } = renderList({ tasks, onClickDelete: jest.fn() });
+      const { taskListItems } = renderList(tasks);
       // then
       expect(taskListItems).toHaveLength(0);
     });
@@ -49,7 +46,7 @@ describe('<List />', () => {
       const taskCount = 10;
       const tasks = [...Array(taskCount)].map((value, index) => ({ id: index + 1, title: `${index} 번째 할 일` }));
       // when
-      const { taskListItems, doneButtons } = renderList({ tasks, onClickDelete: jest.fn() });
+      const { taskListItems, doneButtons } = renderList(tasks);
       // then
       expect(taskListItems).toHaveLength(taskCount);
       expect(doneButtons).toHaveLength(taskCount);
@@ -58,11 +55,11 @@ describe('<List />', () => {
     it('can click the Done buttons', () => {
       // given
       const tasks = [...Array(10)].map((value, index) => ({ id: index + 1, title: `${index} 번째 할 일` }));
-      const handleClickDelete = jest.fn();
+      handleClickDelete.mockClear();
       // when
-      const { clickDoneButton } = renderList({ tasks, onClickDelete: handleClickDelete });
+      const { doneButtons } = renderList(tasks);
       const clickCount = 3;
-      [...Array(clickCount)].forEach((value, index) => clickDoneButton(index));
+      [...Array(clickCount)].forEach((value, index) => fireEvent.click(doneButtons[index]));
       // then
       expect(handleClickDelete).toBeCalledTimes(clickCount);
     });

--- a/src/List.test.jsx
+++ b/src/List.test.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+import { render, fireEvent, screen } from '@testing-library/react';
+
+import List from './List';
+
+describe('List Component는', () => {
+  const mockOnClickDelete = jest.fn();
+
+  beforeEach(() => {
+    mockOnClickDelete.mockClear();
+  });
+
+  describe('할 일이 없다면', () => {
+    const tasks = [];
+
+    test('안내 메시지를 출력한다', () => {
+      const message = '할 일이 없어요!';
+
+      render(<List
+        tasks={tasks}
+        onClickDelete={mockOnClickDelete}
+      />);
+
+      expect(screen.getByText(message)).toBeInTheDocument();
+    });
+
+    test('출력되는 Item이 없다', () => {
+      render(<List
+        tasks={tasks}
+        onClickDelete={mockOnClickDelete}
+      />);
+
+      expect(screen.queryByRole('listitem', { name: '' })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('할 일이 있다면', () => {
+    const itemSize = 10;
+    const tasks = [...Array(itemSize)].map((value, index) => ({ id: index + 1, title: `${index} 할 일` }));
+
+    test('Item 리스트를 출력한다', () => {
+      render(<List
+        tasks={tasks}
+        onClickDelete={mockOnClickDelete}
+      />);
+
+      expect(screen.getByRole('list', { name: '' }).children).toHaveLength(itemSize);
+    });
+
+    describe('Item에서 완료 버튼을 클릭했을 때', () => {
+      test('onClickDelete를 실행한다', () => {
+        render(<List
+          tasks={tasks}
+          onClickDelete={mockOnClickDelete}
+        />);
+
+        fireEvent.click(screen.getAllByRole('button', { name: /완료/i })[0]);
+
+        expect(mockOnClickDelete).toBeCalledTimes(1);
+      });
+    });
+  });
+});

--- a/src/List.test.jsx
+++ b/src/List.test.jsx
@@ -10,9 +10,7 @@ function setup(tasks, handleClickDelete) {
     onClickDelete={handleClickDelete}
   />);
   const clickDoneButton = () => fireEvent.click(screen.getAllByRole('button', { name: /완료/i })[0]);
-  return {
-    clickDoneButton,
-  };
+  return { clickDoneButton };
 }
 
 describe('List Component는', () => {

--- a/src/List.test.jsx
+++ b/src/List.test.jsx
@@ -4,33 +4,33 @@ import { render, fireEvent, screen } from '@testing-library/react';
 
 import List from './List';
 
+function setup(tasks, handleClickDelete) {
+  render(<List
+    tasks={tasks}
+    onClickDelete={handleClickDelete}
+  />);
+  const clickDoneButton = () => fireEvent.click(screen.getAllByRole('button', { name: /완료/i })[0]);
+  return {
+    clickDoneButton,
+  };
+}
+
 describe('List Component는', () => {
-  const mockOnClickDelete = jest.fn();
+  const mockHandleClickDelete = jest.fn();
 
   beforeEach(() => {
-    mockOnClickDelete.mockClear();
+    mockHandleClickDelete.mockClear();
   });
 
   describe('할 일이 없다면', () => {
-    const tasks = [];
-
     test('안내 메시지를 출력한다', () => {
       const message = '할 일이 없어요!';
-
-      render(<List
-        tasks={tasks}
-        onClickDelete={mockOnClickDelete}
-      />);
-
+      setup([], mockHandleClickDelete);
       expect(screen.getByText(message)).toBeInTheDocument();
     });
 
     test('출력되는 Item이 없다', () => {
-      render(<List
-        tasks={tasks}
-        onClickDelete={mockOnClickDelete}
-      />);
-
+      setup([], mockHandleClickDelete);
       expect(screen.queryByRole('listitem', { name: '' })).not.toBeInTheDocument();
     });
   });
@@ -38,26 +38,16 @@ describe('List Component는', () => {
   describe('할 일이 있다면', () => {
     const itemSize = 10;
     const tasks = [...Array(itemSize)].map((value, index) => ({ id: index + 1, title: `${index} 할 일` }));
-
     test('Item 리스트를 출력한다', () => {
-      render(<List
-        tasks={tasks}
-        onClickDelete={mockOnClickDelete}
-      />);
-
+      setup(tasks, mockHandleClickDelete);
       expect(screen.getByRole('list', { name: '' }).children).toHaveLength(itemSize);
     });
 
     describe('Item에서 완료 버튼을 클릭했을 때', () => {
       test('onClickDelete를 실행한다', () => {
-        render(<List
-          tasks={tasks}
-          onClickDelete={mockOnClickDelete}
-        />);
-
-        fireEvent.click(screen.getAllByRole('button', { name: /완료/i })[0]);
-
-        expect(mockOnClickDelete).toBeCalledTimes(1);
+        const { clickDoneButton } = setup(tasks, mockHandleClickDelete);
+        clickDoneButton();
+        expect(mockHandleClickDelete).toBeCalledTimes(1);
       });
     });
   });

--- a/src/Page.test.jsx
+++ b/src/Page.test.jsx
@@ -4,32 +4,25 @@ import { render, fireEvent, screen } from '@testing-library/react';
 
 import Page from './Page';
 
-function renderPage({
-  taskTitle, onChangeTitle, onClickAddTask,
-  tasks, onClickDeleteTask,
-}) {
+const handleChangetitle = jest.fn();
+const handleClickAddTask = jest.fn();
+const handleClickDeleteTask = jest.fn();
+
+function renderPage({ taskTitle, tasks }) {
   render(<Page
     taskTitle={taskTitle}
-    onChangeTitle={onChangeTitle}
-    onClickAddTask={onClickAddTask}
+    onChangeTitle={handleChangetitle}
+    onClickAddTask={handleClickAddTask}
     tasks={tasks}
-    onClickDeleteTask={onClickDeleteTask}
+    onClickDeleteTask={handleClickDeleteTask}
   />);
 
-  const taskTitleInput = screen.getByLabelText(/할 일/i, { selector: 'input' });
-  const addTaskButton = screen.getByRole('button', { name: /추가/i });
-  const nothingTaskMessageElement = screen.queryByText(/할 일이 없어요!/i);
-  const taskListItems = screen.queryAllByRole('listitem', { name: '' });
-  const deleteTaskButtons = screen.queryAllByRole('button', { name: /완료/i });
-
   return {
-    taskTitleInput,
-    nothingTaskMessageElement,
-    taskListItems,
-    deleteTaskButtons,
-    changeTitle: (text) => fireEvent.change(taskTitleInput, { target: { value: text } }),
-    clickAddTaskButton: () => fireEvent.click(addTaskButton),
-    clickDeleteButton: (index) => fireEvent.click(deleteTaskButtons[index]),
+    taskTitleInput: screen.getByLabelText(/할 일/i, { selector: 'input' }),
+    addTaskButton: screen.getByRole('button', { name: /추가/i }),
+    nothingTaskMessageElement: screen.queryByText(/할 일이 없어요!/i),
+    taskListItems: screen.queryAllByRole('listitem', { name: '' }),
+    deleteTaskButtons: screen.queryAllByRole('button', { name: /완료/i }),
   };
 }
 
@@ -41,10 +34,7 @@ describe('<Page />', () => {
       // when
       const { taskTitleInput } = renderPage({
         taskTitle,
-        onChangeTitle: jest.fn(),
-        onClickAddTask: jest.fn(),
         tasks: [],
-        onClickDeleteTask: jest.fn(),
       });
       // then
       expect(taskTitleInput.placeholder).toBe('할 일을 입력해 주세요');
@@ -58,10 +48,7 @@ describe('<Page />', () => {
       // when
       const { taskTitleInput } = renderPage({
         taskTitle,
-        onChangeTitle: jest.fn(),
-        onClickAddTask: jest.fn(),
         tasks: [],
-        onClickDeleteTask: jest.fn(),
       });
       // then
       expect(taskTitleInput.value).toBe(taskTitle);
@@ -71,16 +58,13 @@ describe('<Page />', () => {
   context('when clicked add button', () => {
     it('notify that it has been clicked', () => {
       // given
-      const handleClickAddTask = jest.fn();
+      handleClickAddTask.mockClear();
       // when
-      const { clickAddTaskButton } = renderPage({
+      const { addTaskButton } = renderPage({
         taskTitle: '오늘 할 일',
-        onChangeTitle: jest.fn(),
-        onClickAddTask: handleClickAddTask,
         tasks: [],
-        onClickDeleteTask: jest.fn(),
       });
-      clickAddTaskButton();
+      fireEvent.click(addTaskButton);
       // then
       expect(handleClickAddTask).toBeCalledTimes(1);
     });
@@ -89,16 +73,13 @@ describe('<Page />', () => {
   context('when an input field is entered', () => {
     it('notify that it has been entered', () => {
       // given
-      const handleChangetitle = jest.fn();
+      handleChangetitle.mockClear();
       // when
-      const { changeTitle } = renderPage({
+      const { taskTitleInput } = renderPage({
         taskTitle: '오늘 할 일',
-        onChangeTitle: handleChangetitle,
-        onClickAddTask: jest.fn(),
         tasks: [],
-        onClickDeleteTask: jest.fn(),
       });
-      changeTitle('내일 할 일');
+      fireEvent.change(taskTitleInput, { target: { value: '내일 할 일' } });
       // then
       expect(handleChangetitle).toBeCalledTimes(1);
     });
@@ -111,10 +92,7 @@ describe('<Page />', () => {
       // when
       const { nothingTaskMessageElement } = renderPage({
         taskTitle: '',
-        onChangeTitle: jest.fn(),
-        onClickAddTask: jest.fn(),
         tasks,
-        onClickDeleteTask: jest.fn(),
       });
       // then
       expect(nothingTaskMessageElement).toBeInTheDocument();
@@ -126,10 +104,7 @@ describe('<Page />', () => {
       // when
       const { taskListItems } = renderPage({
         taskTitle: '',
-        onChangeTitle: jest.fn(),
-        onClickAddTask: jest.fn(),
         tasks,
-        onClickDeleteTask: jest.fn(),
       });
       // then
       expect(taskListItems).toHaveLength(0);
@@ -144,10 +119,7 @@ describe('<Page />', () => {
       // when
       const { taskListItems, deleteTaskButtons } = renderPage({
         taskTitle: '',
-        onChangeTitle: jest.fn(),
-        onClickAddTask: jest.fn(),
         tasks,
-        onClickDeleteTask: jest.fn(),
       });
       // then
       expect(taskListItems).toHaveLength(taskCount);
@@ -157,17 +129,14 @@ describe('<Page />', () => {
     it('can click the Done buttons', () => {
       // given
       const tasks = [...Array(10)].map((value, index) => ({ id: index + 1, title: `${index} 번째 할 일` }));
-      const handleClickDeleteTask = jest.fn();
+      handleClickDeleteTask.mockClear();
       // when
-      const { clickDeleteButton } = renderPage({
+      const { deleteTaskButtons } = renderPage({
         taskTitle: '',
-        onChangeTitle: jest.fn(),
-        onClickAddTask: jest.fn(),
         tasks,
-        onClickDeleteTask: handleClickDeleteTask,
       });
       const clickCount = 3;
-      [...Array(clickCount)].forEach((value, index) => clickDeleteButton(index));
+      [...Array(clickCount)].forEach((value, index) => fireEvent.click(deleteTaskButtons[index]));
       // then
       expect(handleClickDeleteTask).toBeCalledTimes(clickCount);
     });

--- a/src/Page.test.jsx
+++ b/src/Page.test.jsx
@@ -17,11 +17,7 @@ function setup(taskTitle, handleChangeTitle,
     { target: { value: text } });
   const clickAddButton = () => fireEvent.click(screen.getByRole('button', { name: /추가/i }));
   const clickDoneButton = () => fireEvent.click(screen.getAllByRole('button', { name: /완료/i })[0]);
-  return {
-    changeTaskInput,
-    clickAddButton,
-    clickDoneButton,
-  };
+  return { changeTaskInput, clickAddButton, clickDoneButton };
 }
 
 describe('Page Component는', () => {

--- a/src/Page.test.jsx
+++ b/src/Page.test.jsx
@@ -1,0 +1,109 @@
+import React from 'react';
+
+import { render, fireEvent, screen } from '@testing-library/react';
+
+import Page from './Page';
+
+function setup(taskTitle, handleChangeTitle,
+  handleClickAddTask, tasks, handleClickDeleteTask) {
+  render(<Page
+    taskTitle={taskTitle}
+    onChangeTitle={handleChangeTitle}
+    onClickAddTask={handleClickAddTask}
+    tasks={tasks}
+    onClickDeleteTask={handleClickDeleteTask}
+  />);
+  const changeTaskInput = (text) => fireEvent.change(screen.getByLabelText(/할 일/i, { selector: 'input' }),
+    { target: { value: text } });
+  const clickAddButton = () => fireEvent.click(screen.getByRole('button', { name: /추가/i }));
+  const clickDoneButton = () => fireEvent.click(screen.getAllByRole('button', { name: /완료/i })[0]);
+  return {
+    changeTaskInput,
+    clickAddButton,
+    clickDoneButton,
+  };
+}
+
+describe('Page Component는', () => {
+  const mockHandleChangeTitle = jest.fn();
+  const mockHandleClickAddTask = jest.fn();
+  const mockHandleClickDeleteTask = jest.fn();
+
+  beforeEach(() => {
+    mockHandleChangeTitle.mockClear();
+    mockHandleClickAddTask.mockClear();
+    mockHandleClickDeleteTask.mockClear();
+  });
+
+  describe('taskTitle 값이', () => {
+    describe('비어 있다면', () => {
+      test('입력 안내 메시지를 출력한다', () => {
+        const placeholderText = '할 일을 입력해 주세요';
+        setup('', mockHandleChangeTitle,
+          mockHandleClickAddTask, [], mockHandleClickDeleteTask);
+        expect(screen.getByPlaceholderText(placeholderText)).toBeInTheDocument();
+      });
+    });
+
+    describe('비어 있지 않다면', () => {
+      test('taskTitle 값을 출력한다.', () => {
+        const taskTitle = '어제보다 열심히 하기';
+        setup(taskTitle, mockHandleChangeTitle,
+          mockHandleClickAddTask, [], mockHandleClickDeleteTask);
+        expect(screen.getByDisplayValue(taskTitle)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('텍스트를 입력하면', () => {
+    test('onChangeTitle를 실행한다', () => {
+      const { changeTaskInput } = setup('어제보다 열심히 하기', mockHandleChangeTitle,
+        mockHandleClickAddTask, [], mockHandleClickDeleteTask);
+      changeTaskInput('새롭게 해야할 일');
+      expect(mockHandleChangeTitle).toBeCalledTimes(1);
+    });
+  });
+
+  describe('추가 버튼을 누르면', () => {
+    test('onClickAddTask을 실행한다', () => {
+      const { clickAddButton } = setup('어제보다 열심히 하기', mockHandleChangeTitle,
+        mockHandleClickAddTask, [], mockHandleClickDeleteTask);
+      clickAddButton();
+      expect(mockHandleClickAddTask).toBeCalledTimes(1);
+    });
+  });
+
+  describe('할 일이 없다면', () => {
+    test('안내 메시지를 출력한다', () => {
+      const message = '할 일이 없어요!';
+      setup('', mockHandleChangeTitle,
+        mockHandleClickAddTask, [], mockHandleClickDeleteTask);
+      expect(screen.getByText(message)).toBeInTheDocument();
+    });
+
+    test('출력되는 Item이 없다', () => {
+      setup('', mockHandleChangeTitle,
+        mockHandleClickAddTask, [], mockHandleClickDeleteTask);
+      expect(screen.queryByRole('listitem', { name: '' })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('할 일이 있다면', () => {
+    const itemSize = 10;
+    const tasks = [...Array(itemSize)].map((value, index) => ({ id: index + 1, title: `${index} 할 일` }));
+    test('Item 리스트를 출력한다', () => {
+      setup('', mockHandleChangeTitle,
+        mockHandleClickAddTask, tasks, mockHandleClickDeleteTask);
+      expect(screen.getByRole('list', { name: '' }).children).toHaveLength(itemSize);
+    });
+
+    describe('Item의 완료 버튼을 클릭했을 때', () => {
+      test('onClickDeleteTask 실행한다', () => {
+        const { clickDoneButton } = setup('', mockHandleChangeTitle,
+          mockHandleClickAddTask, tasks, mockHandleClickDeleteTask);
+        clickDoneButton();
+        expect(mockHandleClickDeleteTask).toBeCalledTimes(1);
+      });
+    });
+  });
+});


### PR DESCRIPTION
트레이너님, 안녕하세요.
3주차 과제 제출합니다. :)

1. setup() 함수 정의
- 하나의 컴포넌트를 테스트할 때 테스트 케이스 별로 중복되는 코드가 존재하였습니다.
- 중복되는 코드를 setup() 함수로 추상화하여 중복을 줄였습니다.
- setup() 함수는 컴포넌트를 그릴 때 필요한 props들을 매개변수로 받고, 컴포넌트의 행위들을 반환합니다.
- 각 테스트 케이스에서는 setup() 함수를 호출하여 컴포넌트를 그리고, setup() 함수의 반환 값을 이용해 여러 행위를 테스트할 수 있습니다.

2. 인터페이스 중심의 테스트
- child를 갖는 parent 컴포넌트를 테스트할 때 child를 mock 처리하려고 하였으나, 테스트 코드는 사용자 입장인 인터페이스를 중심으로 하는 것이 좋다고 생각해 따로 이벤트 핸들러 외에 mock 처리는 하지 않았습니다.
- 특히 App 컴포넌트의 테스트는 기존에 존재하던 e2e 테스트를 옮겨왔습니다.

감사합니다.